### PR TITLE
Make inserter requirements closer to buildings they match

### DIFF
--- a/FluidShipping/BottleInserterConfig.cs
+++ b/FluidShipping/BottleInserterConfig.cs
@@ -23,11 +23,11 @@ namespace StormShark.OniFluidShipping
 			int hitpoints = 30;
 			float construction_time = 10f;
 			float[] tieR4 = TUNING.BUILDINGS.CONSTRUCTION_MASS_KG.TIER4;
-			string[] rawMinerals = MATERIALS.RAW_MINERALS;
+			string[] materials = MATERIALS.ALL_METALS;
 			float melting_point = 1600f;
 			BuildLocationRule build_location_rule = BuildLocationRule.OnFloor;
 			EffectorValues none = NOISE_POLLUTION.NONE;
-			BuildingDef buildingDef = BuildingTemplates.CreateBuildingDef(id, width, height, anim, hitpoints, construction_time, tieR4, rawMinerals, melting_point, build_location_rule, TUNING.BUILDINGS.DECOR.PENALTY.TIER1, none, 0.2f);
+			BuildingDef buildingDef = BuildingTemplates.CreateBuildingDef(id, width, height, anim, hitpoints, construction_time, tieR4, materials, melting_point, build_location_rule, TUNING.BUILDINGS.DECOR.PENALTY.TIER1, none, 0.2f);
 			buildingDef.Floodable = false;
 			buildingDef.AudioCategory = "Metal";
 			buildingDef.Overheatable = false;

--- a/FluidShipping/CanisterInserterConfig.cs
+++ b/FluidShipping/CanisterInserterConfig.cs
@@ -26,12 +26,12 @@ namespace StormShark.OniFluidShipping
 			string anim = "stormshark_canisterinserter_kanim";
 			int hitpoints = 30;
 			float construction_time = 10f;
-			float[] tieR4 = TUNING.BUILDINGS.CONSTRUCTION_MASS_KG.TIER4;
-			string[] rawMinerals = MATERIALS.RAW_MINERALS;
+			float[] tieR4 = TUNING.BUILDINGS.CONSTRUCTION_MASS_KG.TIER2;
+			string[] materials = MATERIALS.REFINED_METALS;
 			float melting_point = 1600f;
 			BuildLocationRule build_location_rule = BuildLocationRule.OnFloor;
 			EffectorValues none = NOISE_POLLUTION.NONE;
-			BuildingDef buildingDef = BuildingTemplates.CreateBuildingDef(id, width, height, anim, hitpoints, construction_time, tieR4, rawMinerals, melting_point, build_location_rule, TUNING.BUILDINGS.DECOR.PENALTY.TIER1, none, 0.2f);
+			BuildingDef buildingDef = BuildingTemplates.CreateBuildingDef(id, width, height, anim, hitpoints, construction_time, tieR4, materials, melting_point, build_location_rule, TUNING.BUILDINGS.DECOR.PENALTY.TIER1, none, 0.2f);
 			buildingDef.Floodable = false;
 			buildingDef.AudioCategory = "Metal";
 			buildingDef.Overheatable = false;

--- a/FluidShipping/CanisterInserterConfig.cs
+++ b/FluidShipping/CanisterInserterConfig.cs
@@ -32,7 +32,7 @@ namespace StormShark.OniFluidShipping
 			BuildLocationRule build_location_rule = BuildLocationRule.OnFloor;
 			EffectorValues none = NOISE_POLLUTION.NONE;
 			BuildingDef buildingDef = BuildingTemplates.CreateBuildingDef(id, width, height, anim, hitpoints, construction_time, tieR4, materials, melting_point, build_location_rule, TUNING.BUILDINGS.DECOR.PENALTY.TIER1, none, 0.2f);
-			buildingDef.Floodable = false;
+			buildingDef.Floodable = true;
 			buildingDef.AudioCategory = "Metal";
 			buildingDef.Overheatable = false;
 			buildingDef.OutputConduitType = ConduitType.Gas;


### PR DESCRIPTION
Make inserter buildings match more the buildings they improve upon (emptier+pump). Liquid pump requires metal, and gas emptier requires refined metal, so it seems a bit OP to require only raw minerals.

I've checked and this does not affect existing saves (existing buildings stay being made of raw minerals).

