### PR TITLE
inserter buildings should require power

### DIFF
--- a/FluidShipping/BottleInserterConfig.cs
+++ b/FluidShipping/BottleInserterConfig.cs
@@ -34,6 +34,14 @@ namespace StormShark.OniFluidShipping
 			buildingDef.OutputConduitType = ConduitType.Liquid;
 			buildingDef.UtilityOutputOffset = new CellOffset(0, 1);
 			buildingDef.ViewMode = OverlayModes.LiquidConduits.ID;
+			if(BuildingGenerationPatches.Options.BottleInserterRequiresPower)
+			{
+				buildingDef.RequiresPowerInput = true;
+				buildingDef.EnergyConsumptionWhenActive = 120f; // half of liquid pump
+				buildingDef.ExhaustKilowattsWhenActive = 0f;
+				buildingDef.SelfHeatKilowattsWhenActive = 1f; // half of liquid pump
+				buildingDef.PowerInputOffset = new CellOffset(0, 0);
+			}
 			return buildingDef;
 		}
 
@@ -53,6 +61,8 @@ namespace StormShark.OniFluidShipping
 			storage.capacityKg = BuildingGenerationPatches.Options.BottleVolume; //200 kg default
 			go.AddOrGet<TreeFilterable>();
 			go.AddOrGet<VesselInserter>();
+			if(BuildingGenerationPatches.Options.BottleInserterRequiresPower)
+				go.AddOrGet<ConduitDispenser>().alwaysDispense = false;
 		}
 
 		public override void DoPostConfigureComplete(GameObject go)

--- a/FluidShipping/CanisterInserterConfig.cs
+++ b/FluidShipping/CanisterInserterConfig.cs
@@ -38,6 +38,14 @@ namespace StormShark.OniFluidShipping
 			buildingDef.OutputConduitType = ConduitType.Gas;
 			buildingDef.UtilityOutputOffset = new CellOffset(0, 1);
 			buildingDef.ViewMode = OverlayModes.GasConduits.ID;
+			if(BuildingGenerationPatches.Options.CanisterInserterRequiresPower)
+			{
+				buildingDef.RequiresPowerInput = true;
+				buildingDef.EnergyConsumptionWhenActive = 120f; // half of gas pump
+				buildingDef.ExhaustKilowattsWhenActive = 0f;
+				buildingDef.SelfHeatKilowattsWhenActive = 0; // 0 just like gas pump
+				buildingDef.PowerInputOffset = new CellOffset(0, 0);
+			}
 			return buildingDef;
 		}
 
@@ -59,6 +67,8 @@ namespace StormShark.OniFluidShipping
 			conduitDispenser.alwaysDispense = true;
 			go.AddOrGet<TreeFilterable>();
 			go.AddOrGet<VesselInserter>();
+			if(BuildingGenerationPatches.Options.CanisterInserterRequiresPower)
+				go.AddOrGet<ConduitDispenser>().alwaysDispense = false;
 		}
 
 		public override void DoPostConfigureComplete(GameObject go)

--- a/FluidShipping/FluidShippingOptions.cs
+++ b/FluidShipping/FluidShippingOptions.cs
@@ -23,17 +23,28 @@ namespace StormShark.OniFluidShipping
 		[JsonProperty]
 		public float BottleFillerVolume { get; set; }
 
+		[Option("Canister Inserter Requires Power", "Canister Inserter requires 120W (half of Gas Pump power).")]
+		[JsonProperty]
+		public bool CanisterInserterRequiresPower { get; set; }
+
+		[Option("Bottle Inserter Requires Power", "Bottle Inserter requires 120W (half of Liquid Pump power).")]
+		[JsonProperty]
+		public bool BottleInserterRequiresPower { get; set; }
+
 
 		public FluidShippingOptions()
 		{
 			CanisterVolume = 10;
 			BottleVolume = 200;
 			BottleFillerVolume = 200;
+			CanisterInserterRequiresPower = false;
+			BottleInserterRequiresPower = false;
 		}
 
 		public override string ToString()
 		{
-			return "FluidShippingOptions[liquidKg={0:D},gasKg{1:D},liquidFillerKg={2:D}]".F(CanisterVolume, BottleVolume, BottleFillerVolume);
+			return "FluidShippingOptions[liquidKg={0:D},gasKg{1:D},liquidFillerKg={2:D},gasPower={3},liquidPower={4}]"
+			    .F(CanisterVolume, BottleVolume, BottleFillerVolume, CanisterInserterRequiresPower, BottleInserterRequiresPower);
 		}
 	}
 }


### PR DESCRIPTION
Since they are essentially emptier+pump buildings combine, it seems a bit OP to not have them require any power. They can probably be more efficient since they already contain the element, but they still should use at least some. Use half of what pumps need.

I personally think this should be simply the non-configurable default, but that would break existing saves. So for backwards compatibility, this is optional and disabled by default :-/. I don't see much point in being able to configure the exact power usage, and it'd also make it harder to know what to change it to in order to have this somewhat balanced (since the default then would be presumably 0). Feel free to tweak as you see fit.
