### PR TITLE
fix auto-bottle

### DIFF
--- a/FluidShipping/LiquidBottler.cs
+++ b/FluidShipping/LiquidBottler.cs
@@ -53,7 +53,10 @@ namespace StormShark.OniFluidShipping
 				{
 					smi.master.storage.allowItemRemoval = true;
 					foreach (GameObject go in smi.master.storage.items)
+					{
+						go.GetComponent<KPrefabID>().AddTag(GameTags.LiquidSource);
 						go.Trigger(-778359855, (object)smi.master.storage);
+					}
 				})).Exit((StateMachine<LiquidBottler.Controller, LiquidBottler.Controller.Instance, LiquidBottler, object>.State.Callback)(smi =>
 				{
 					smi.master.storage.allowItemRemoval = false;

--- a/FluidShipping/VesselInserter.cs
+++ b/FluidShipping/VesselInserter.cs
@@ -88,9 +88,10 @@ namespace StormShark.OniFluidShipping
 					component1.TintColour = (Color32)VesselInserter.filterTint;
 					Tag[] forbidden_tags;
 					if (!this.master.allowManualPumpingStationFetching)
-						forbidden_tags = new Tag[1]
+						forbidden_tags = new Tag[2]
 						{
-							GameTags.LiquidSource
+							GameTags.LiquidSource,
+							GameTags.GasSource
 						};
 					else
 						forbidden_tags = new Tag[0];


### PR DESCRIPTION
Bottling buildings should be marked with GasSource/LiquidSource, and buildings with auto-bottle disabled should disable them for fetching.