### PR TITLE
add building subcategories

### DIFF
--- a/FluidShipping/BottleFillerConfig.cs
+++ b/FluidShipping/BottleFillerConfig.cs
@@ -97,7 +97,7 @@ namespace StormShark.OniFluidShipping
 			Strings.Add($"STRINGS.BUILDINGS.PREFABS.{S_BF_ID.ToUpperInvariant()}.DESC", Description);
 			Strings.Add($"STRINGS.BUILDINGS.PREFABS.{S_BF_ID.ToUpperInvariant()}.EFFECT", Effect);
 
-			ModUtil.AddBuildingToPlanScreen("Plumbing", S_BF_ID);
+			ModUtil.AddBuildingToPlanScreen("Plumbing", S_BF_ID, "valves");
 		}
 	}
 }

--- a/FluidShipping/BottleInserterConfig.cs
+++ b/FluidShipping/BottleInserterConfig.cs
@@ -70,7 +70,7 @@ namespace StormShark.OniFluidShipping
 			Strings.Add($"STRINGS.BUILDINGS.PREFABS.{S_BI_ID.ToUpperInvariant()}.DESC", Description);
 			Strings.Add($"STRINGS.BUILDINGS.PREFABS.{S_BI_ID.ToUpperInvariant()}.EFFECT", Effect);
 
-			ModUtil.AddBuildingToPlanScreen("Plumbing", S_BI_ID);
+			ModUtil.AddBuildingToPlanScreen("Plumbing", S_BI_ID, "valves");
 		}
 	}
 }

--- a/FluidShipping/CanisterInserterConfig.cs
+++ b/FluidShipping/CanisterInserterConfig.cs
@@ -76,7 +76,7 @@ namespace StormShark.OniFluidShipping
 			Strings.Add($"STRINGS.BUILDINGS.PREFABS.{S_CI_ID.ToUpperInvariant()}.DESC", Description);
 			Strings.Add($"STRINGS.BUILDINGS.PREFABS.{S_CI_ID.ToUpperInvariant()}.EFFECT", Effect);
 
-			ModUtil.AddBuildingToPlanScreen("HVAC", S_CI_ID);
+			ModUtil.AddBuildingToPlanScreen("HVAC", S_CI_ID, "valves");
 		}
 	}
 }

--- a/FluidShipping/Patches.cs
+++ b/FluidShipping/Patches.cs
@@ -31,9 +31,9 @@ namespace StormShark.OniFluidShipping
 				var newOptions = POptions.ReadSettings<FluidShippingOptions>();
 				if (newOptions != null) Options = newOptions;
 
+				BottleFillerConfig.Setup();
 				BottleInserterConfig.Setup();
 				CanisterInserterConfig.Setup();
-				BottleFillerConfig.Setup();
 			}
 		}
 


### PR DESCRIPTION
Without these, the buildings are listed first in the build menus. Also bottle filler should go first, just like vanilla gas bottler does.