### PR TITLE
use [RestartRequired]

### DIFF
--- a/FluidShipping/FluidShippingOptions.cs
+++ b/FluidShipping/FluidShippingOptions.cs
@@ -9,6 +9,7 @@ namespace StormShark.OniFluidShipping
 	/// </summary>
 	[ModInfo("https://github.com/RavenDreamer/ONIMods", "previewv2.png")]
 	[JsonObject(MemberSerialization.OptIn)]
+	[RestartRequired]
 	public sealed class FluidShippingOptions
 	{
 		[Option("Canister Inserter Volume", "Internal storage volume of Canister Inserter (Kg).")]


### PR DESCRIPTION
BuildingDef's are created during game initialization.

The problem of that person on Steam complaining about power is presumably caused by you shipping a config.json and that person not restarting the game after changing it back to coded defaults (the only valid criticism in those comments as far as I am concerned, I guess that's what you get when you ship an OP mod for a while and people get used to it).
